### PR TITLE
feat: Implement basic CLI for command execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,50 @@
-# aia
+# Command Executor CLI
+
+A simple Node.js command-line tool to execute commands passed as arguments.
+
+## Prerequisites
+
+- Node.js installed on your system.
+
+## Setup
+
+1.  **Make the script executable:**
+    Before running the script directly, you need to give it execute permissions.
+
+    ```bash
+    chmod +x index.js
+    ```
+
+## Usage
+
+Once the script is executable, you can run it from your terminal:
+
+```bash
+./index.js <command> [arguments...]
+```
+
+-   `<command>`: The command you want to execute (e.g., `ls`, `echo`, `node`).
+-   `[arguments...]`: Any arguments for that command (e.g., `-la` for `ls`, `"Hello World"` for `echo`).
+
+### Examples
+
+1.  **List files in the current directory:**
+
+    ```bash
+    ./index.js ls -la
+    ```
+
+2.  **Echo a message:**
+
+    ```bash
+    ./index.js echo "Hello from the CLI!"
+    ```
+
+3.  **Check Node.js version:**
+    ```bash
+    ./index.js node --version
+    ```
+
+## How it Works
+
+The `index.js` script uses Node.js's `child_process.spawn` method to execute the provided command. It pipes the standard output (stdout) and standard error (stderr) of the child process to the main process, so you see the command's output directly in your terminal. It also handles basic errors, such as the command not being found or the command exiting with an error code.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+const { spawn } = require('child_process');
+
+const command = process.argv[2];
+const args = process.argv.slice(3);
+
+if (!command) {
+  console.error('Usage: npx execute-command <command> [args...]');
+  process.exit(1);
+}
+
+// Use 'pipe' to capture stdio and manually pipe it
+const child = spawn(command, args, { stdio: ['pipe', 'pipe', 'pipe'] });
+
+// Pipe stdout
+child.stdout.on('data', (data) => {
+  process.stdout.write(data);
+});
+
+// Pipe stderr
+child.stderr.on('data', (data) => {
+  process.stderr.write(data);
+});
+
+child.on('error', (error) => {
+  if (error.code === 'ENOENT') {
+    console.error(`Error: Command "${command}" not found.`);
+  } else {
+    console.error(`Failed to start subprocess: ${error.message}`);
+  }
+  process.exit(1); // Exit if the process could not be spawned or was killed
+});
+
+// Using 'close' event as it's called after stdio streams have been closed
+// 'exit' might be called before all stdio data is written out
+child.on('close', (code, signal) => {
+  if (signal) {
+    console.error(`\nSubprocess killed by signal: ${signal}`);
+    process.exit(1); // Standard practice to exit with 1 on error/signal
+  } else if (code !== 0) {
+    // Outputting a newline before error message for clarity if command produced partial output
+    console.error(`\nSubprocess exited with error code: ${code}`);
+    process.exit(code);
+  }
+  // If code is 0 and no signal, exit normally (implicitly or explicitly with process.exit(0))
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Blankenship-Daniel/aia.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/Blankenship-Daniel/aia/issues"
+  },
+  "homepage": "https://github.com/Blankenship-Daniel/aia#readme"
+}


### PR DESCRIPTION
This commit introduces the first phase of the NodeJS CLI tool.

Key features:
- Initializes a NodeJS project with a main executable script (`index.js`).
- Accepts commands and arguments from the command line.
- Executes commands on Mac OS X.
- Displays output from the executed commands.
- Includes basic error handling for command execution failures (e.g., command not found, non-zero exit codes).
- Adds a README.md with instructions on how to set up and run the tool.

This provides the foundational functionality for the CLI tool, allowing you to run terminal commands.